### PR TITLE
fix: use stream_select to avoid hanging behaviour

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -11,7 +11,9 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::{FramedRead, FramedWrite};
 
 use futures::channel::mpsc;
-use futures::{future, join, stream, FutureExt, Sink, SinkExt, Stream, StreamExt, TryFutureExt};
+use futures::{
+    future, join, stream, stream_select, FutureExt, Sink, SinkExt, Stream, StreamExt, TryFutureExt,
+};
 use tower::Service;
 use tracing::error;
 
@@ -27,7 +29,7 @@ const MESSAGE_QUEUE_SIZE: usize = 100;
 /// This socket handles the server-to-client half of the bidirectional communication stream.
 pub trait Loopback {
     /// Yields a stream of pending server-to-client requests.
-    type RequestStream: Stream<Item = Request>;
+    type RequestStream: Stream<Item = Request> + Unpin;
     /// Routes client-to-server responses back to the server.
     type ResponseSink: Sink<Response> + Unpin;
 
@@ -120,7 +122,7 @@ where
             .forward(responses_tx.clone().sink_map_err(|_| unreachable!()))
             .map(|_| ());
 
-        let print_output = stream::select(responses_rx, client_requests.map(Message::Request))
+        let print_output = stream_select!(responses_rx, client_requests.map(Message::Request))
             .map(Ok)
             .forward(framed_stdout.sink_map_err(|e| error!("failed to encode message: {}", e)))
             .map(|_| ());


### PR DESCRIPTION
See original issue https://github.com/ebkalderon/tower-lsp/pull/414
Depends on #6

Default `futures::stream::select` uses round-robin strategy which alternate the stream polled and waits instead of polling the other. The `futures::stream_select!` macro instead properly polls both streams and returns the first one.

- [ ] add a test (see original issue for reproduction)