### PR TITLE
Actually exit after receiving `exit` notification

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -55,7 +55,7 @@ impl Display for ExitedError {
 #[derive(Debug)]
 pub struct LspService<S> {
     inner: Router<S, ExitedError>,
-    state: Arc<ServerState>,
+    pub(crate) state: Arc<ServerState>,
 }
 
 impl<S: LanguageServer> LspService<S> {


### PR DESCRIPTION
(This is a re-post of https://github.com/ebkalderon/tower-lsp/pull/428, but to this fork which appears to be maintained)

This fixes https://github.com/ebkalderon/tower-lsp/issues/399 and https://github.com/ebkalderon/tower-lsp/issues/424.