### PR TITLE
Change project name to `tower-lsp-server`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: rust ci
+name: Rust CI
 
 on:
   push:
@@ -26,7 +26,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-version }}
 
-    - name: test tower-lsp with runtime ${{ matrix.runtime }}
+    - name: test with runtime ${{ matrix.runtime }}
       run: |
         cargo +${{ matrix.rust-version }} test --workspace --no-default-features --features ${{ matrix.runtime }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to tower-lsp
+# Contributing to tower-lsp-server
 
-`tower-lsp` is an open-source project that values community contribution. We
+`tower-lsp-server` is an open-source project that values community contribution. We
 could always use a helping hand! What would you like to do?
 
 1. [I want to submit issues or request features.](#submitting-issues)
@@ -9,25 +9,17 @@ could always use a helping hand! What would you like to do?
 
 ## Submitting issues
 
-One way you can help `tower-lsp` is to report bugs or request features on our
-GitHub issue trackers. We can't fix problems we don't know about, so please
-report early and often!
+One way you can help `tower-lsp-server` is to report bugs or request features on our GitHub issue trackers. We can't fix problems we don't know about, so please report early and often!
 
-When reporting a bug or asking for help, please include enough details so that
-the people helping you can reproduce the behavior you are seeing. For some tips
-on how to approach this, read about how to produce a
-[Minimal, Complete, and Verifiable example][mcve].
+When reporting a bug or asking for help, please include enough details so that the people helping you can reproduce the behavior you are seeing. For some tips on how to approach this, read about how to produce a [Minimal, Complete, and Verifiable example][mcve].
 
 [mcve]: https://stackoverflow.com/help/mcve
 
-When making a feature request, please make it clear what problem you intend to
-solve with the feature, any ideas for how `tower-lsp` could support solving that
-problem, any possible alternatives, and any disadvantages.
+When making a feature request, please make it clear what problem you intend to solve with the feature, any ideas for how `tower-lsp-server` could support solving that problem, any possible alternatives, and any disadvantages.
 
 ## Contributing code
 
-The general workflow for contributing code to the `tower-lsp` repository is as
-follows:
+The general workflow for contributing code to the `tower-lsp-server` repository is as follows:
 
 1. Fork this repository to your own GitHub account.
 2. `git clone` the forked repository to your local machine.
@@ -35,10 +27,9 @@ follows:
 4. Make your changes and push them up to the forked repository.
 5. [Open a pull request] against this repository.
 
-[Open a pull request]: https://github.com/ebkalderon/tower-lsp/compare
+[Open a pull request]: https://github.com/tower-lsp-community/tower-lsp-server/compare
 
-Before submitting your pull request, please make sure the following conditions
-are satisfied:
+Before submitting your pull request, please make sure the following conditions are satisfied:
 
 1. The pull request is based on an up-to-date version of your respective branch.
 2. If your pull request introduces new functionality, you have written test
@@ -55,44 +46,31 @@ are satisfied:
 
 [this example]: ./src/codec.rs#L129-L157
 
-We encourage you to check that the test suite passes locally before submitting a
-pull request with your changes. If anything does not pass, typically it will be
-easier to iterate and fix it locally than waiting for the CI servers to run
-tests for you.
+We encourage you to check that the test suite passes locally before submitting a pull request with your changes. If anything does not pass, typically it will be easier to iterate and fix it locally than waiting for the CI servers to run tests for you.
 
-Thank you very much for your contribution! Now `tower-lsp` will be a little
-faster, more ergonomic, and more efficient.
+Thank you very much for your contribution! Now `tower-lsp-server` will be a little faster, more ergonomic, and more efficient.
 
 ## Writing documentation
 
 Documentation improvements are always welcome!
 
-As with most Rust projects, API documentation is generated directly from doc
-comments, denoted by either `///` or `//!`, using a tool called Rustdoc. See
-[the official Rust book's chapter on Rustdoc][rd] for more information on how
-this works.
+As with most Rust projects, API documentation is generated directly from doc comments, denoted by either `///` or `//!`, using a tool called Rustdoc. See [the official Rust book's chapter on Rustdoc][rd] for more information on how this works.
 
 [rd]: https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments
 
 Documentation of any kind should adhere to the following standard:
 
 1. Lines must not extend beyond 80 characters in length.
-2. To enhance readability in text editors and terminals, use only *reference
-   style* Markdown links, as shown in the example below. However, if the link
-   points to an anchor that exists on the same page, the *inline style* should
-   be used instead.
+2. To enhance readability in text editors and terminals, use only *reference style* Markdown links, as shown in the example below. However, if the link points to an anchor that exists on the same page, the *inline style* should be used instead.
 
 ```markdown
-Here is some [example text] with a link in it. While we are at it, here is yet
-yet [another link][al], but shorter. If we are linking to [an anchor](#anchor)
-on the same page, we can do this inline.
+Here is some [example text] with a link in it. While we are at it, here is yet yet [another link][al], but shorter. If we are linking to [an anchor](#anchor) on the same page, we can do this inline.
 
 [example text]: https://some.url/
 [al]: https://another.url/
 ```
 
-When submitting your pull requests, please follow the same workflow described in
-the [Contributing Code](#contributing-code) section above.
+When submitting your pull requests, please follow the same workflow described in the [Contributing Code](#contributing-code) section above.
 
 ## Code of conduct
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,8 +798,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
+name = "tower-lsp-server"
+version = "0.21.0"
 dependencies = [
  "async-codec-lite",
  "async-trait",
@@ -816,14 +816,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-lsp-macros",
+ "tower-lsp-server-macros",
  "tracing",
  "tracing-subscriber",
  "ws_stream_tungstenite",
 ]
 
 [[package]]
-name = "tower-lsp-macros"
+name = "tower-lsp-server-macros"
 version = "0.9.0"
 dependencies = [
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "tower-lsp"
-version = "0.20.0"
+name = "tower-lsp-server"
+version = "0.21.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 edition = "2021"
 description = "Language Server Protocol implementation based on Tower"
 license = "MIT OR Apache-2.0"
-homepage = "https://github.com/ebkalderon/tower-lsp"
-repository = "https://github.com/ebkalderon/tower-lsp"
-documentation = "https://docs.rs/tower-lsp/"
+homepage = "https://github.com/tower-lsp-community/tower-lsp-server"
+repository = "https://github.com/tower-lsp-community/tower-lsp-server"
+documentation = "https://docs.rs/tower-lsp-server/"
 readme = "README.md"
 categories = ["asynchronous"]
 keywords = ["language-server", "lsp", "tower"]
@@ -21,7 +21,7 @@ runtime-tokio = ["tokio", "tokio-util"]
 proposed = ["lsp-types/proposed"]
 
 [dependencies]
-tower-lsp-macros = { version = "0.9", path = "./tower-lsp-macros" }
+tower-lsp-server-macros = { version = "0.9", path = "./tower-lsp-server-macros" }
 
 async-codec-lite = { version = "0.0", optional = true }
 async-trait = "0.1"
@@ -47,5 +47,5 @@ tracing-subscriber = "0.3"
 ws_stream_tungstenite = { version = "0.14", features = ["tokio_io"] }
 
 [workspace]
-members = [".", "./tower-lsp-macros"]
+members = [".", "./tower-lsp-server-macros"]
 default-members = ["."]

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,18 +1,13 @@
 # Supported Features
 
-This document tracks which features defined in the [Language Server Protocol
-(LSP) specification][spec] are currently supported by `tower-lsp` and to what
-degree. Please note that this document is provided _as-is_ and will be updated
-over time on a best-effort basis. There is no guarantee that it will always
-reflect the current reality exactly on the mainline branch. However, it should
-be updated on every `tower-lsp` release at minimum.
+This document tracks which features defined in the [Language Server Protocol (LSP) specification][spec] are currently supported by `tower-lsp-server` and to what degree. Please note that this document is provided _as-is_ and will be updated over time on a best-effort basis. There is no guarantee that it will always reflect the current reality exactly on the mainline branch. However, it should be updated on every `tower-lsp-server` release at minimum.
 
 [spec]: https://microsoft.github.io/language-server-protocol/specification
 
 Feel free to open a new [discussion thread] if there are any questions. Drive-by
 pull requests correcting this document are always welcome!
 
-[discussion thread]: https://github.com/ebkalderon/tower-lsp/discussions
+[discussion thread]: https://github.com/tower-lsp-community/tower-lsp-server/discussions
 
 <details><summary>Click here to expand/collapse the icon legend.</summary>
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,28 @@
-# tower-lsp
+# tower-lsp-server
 
 [![CI][ci-badge]][ci-badge-url]
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 
-[ci-badge]: https://github.com/tower-lsp/tower-lsp/actions/workflows/ci.yml/badge.svg?branch=master
-[ci-badge-url]: https://github.com/tower-lsp/tower-lsp/actions
-[crates-badge]: https://img.shields.io/crates/v/tower-lsp.svg
-[crates-url]: https://crates.io/crates/tower-lsp
-[docs-badge]: https://docs.rs/tower-lsp/badge.svg
-[docs-url]: https://docs.rs/tower-lsp
+[ci-badge]: https://github.com/tower-lsp-community/tower-lsp-server/actions/workflows/rust.yml/badge.svg?branch=main
+[ci-badge-url]: https://github.com/tower-lsp-community/tower-lsp-server/actions
+[crates-badge]: https://img.shields.io/crates/v/tower-lsp-server.svg
+[crates-url]: https://crates.io/crates/tower-lsp-server
+[docs-badge]: https://docs.rs/tower-lsp-server/badge.svg
+[docs-url]: https://docs.rs/tower-lsp-server
 
 [Language Server Protocol] implementation for Rust based on [Tower].
 
 [language server protocol]: https://microsoft.github.io/language-server-protocol
 [tower]: https://github.com/tower-rs/tower
 
-Tower is a simple and composable framework for implementing asynchronous
-services in Rust. Central to Tower is the [`Service`] trait, which provides the
-necessary abstractions for defining request/response clients and servers.
-Examples of protocols implemented using the `Service` trait include
-[`hyper`] for HTTP and [`tonic`] for gRPC.
+Tower is a simple and composable framework for implementing asynchronous services in Rust. Central to Tower is the [`Service`] trait, which provides the necessary abstractions for defining request/response clients and servers. Examples of protocols implemented using the `Service` trait include [`hyper`] for HTTP and [`tonic`] for gRPC.
 
 [`service`]: https://docs.rs/tower-service/
 [`hyper`]: https://docs.rs/hyper/
 [`tonic`]: https://docs.rs/tonic/
 
-This library (`tower-lsp`) provides a simple implementation of the Language
-Server Protocol (LSP) that makes it easy to write your own language server. It
-consists of three parts:
+`tower-lsp-server` provides a simple implementation of the Language Server Protocol (LSP) that makes it easy to write your own language server. It consists of three parts:
 
 - The `LanguageServer` trait which defines the behavior of your language server.
 - The asynchronous `LspService` delegate which wraps your language server
@@ -77,13 +71,12 @@ async fn main() {
 
 # Using runtimes other than tokio
 
-By default, `tower-lsp` is configured for use with `tokio`.
+By default, `tower-lsp-server` is configured for use with `tokio`.
 
-Using `tower-lsp` with other runtimes requires disabling `default-features` and
-enabling the `runtime-agnostic` feature:
+Using `tower-lsp-server` with other runtimes requires disabling `default-features` and enabling the `runtime-agnostic` feature:
 
 ```toml
-[dependencies.tower-lsp]
+[dependencies.tower-lsp-server]
 version = "*"
 default-features = false
 features = ["runtime-agnostic"]
@@ -91,13 +84,9 @@ features = ["runtime-agnostic"]
 
 # Using proposed features
 
-You can use enable proposed features in the
-[LSP Specification version 3.18](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/)
-by enabling the `proposed` Cargo crate feature. Note that there are no semver
-guarantees to the `proposed` features so there may be breaking changes between
-any type of version in the `proposed` features.
+You can use enable proposed features in the [LSP Specification version 3.18](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/) by enabling the `proposed` Cargo crate feature. Note that there are no semver guarantees to the `proposed` features so there may be breaking changes between any type of version in the `proposed` features.
 
-# Projects using `tower-lsp`
+# Projects using `tower-lsp-server`
 
 - [Harper](https://github.com/Automattic/harper)
 - [Deno](https://github.com/denoland/deno/tree/main/cli/lsp)
@@ -110,10 +99,6 @@ any type of version in the `proposed` features.
 
 # License
 
-`tower-lsp` is free and open source software distributed under the terms of
-either the [MIT](LICENSE-MIT) or the [Apache 2.0](LICENSE-APACHE) license, at
-your option.
+`tower-lsp-server` is free and open source software distributed under the terms of either the [MIT](LICENSE-MIT) or the [Apache 2.0](LICENSE-APACHE) license, at your option.
 
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ Tower is a simple and composable framework for implementing asynchronous service
 # Example
 
 ```rust
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::*;
-use tower_lsp::{Client, LanguageServer, LspService, Server};
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::*;
+use tower_lsp_server::{Client, LanguageServer, LspService, Server};
 
 #[derive(Debug)]
 struct Backend {
     client: Client,
 }
 
-#[tower_lsp::async_trait]
+#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult::default())

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
-use tower_lsp::jsonrpc::{Error, Result};
-use tower_lsp::lsp_types::notification::Notification;
-use tower_lsp::lsp_types::*;
-use tower_lsp::{Client, LanguageServer, LspService, Server};
+use tower_lsp_server::jsonrpc::{Error, Result};
+use tower_lsp_server::lsp_types::notification::Notification;
+use tower_lsp_server::lsp_types::*;
+use tower_lsp_server::{Client, LanguageServer, LspService, Server};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct CustomNotificationParams {
@@ -32,7 +32,7 @@ struct Backend {
     client: Client,
 }
 
-#[tower_lsp::async_trait]
+#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -1,13 +1,13 @@
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::*;
-use tower_lsp::{Client, LanguageServer, LspService, Server};
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::*;
+use tower_lsp_server::{Client, LanguageServer, LspService, Server};
 
 #[derive(Debug)]
 struct Backend {
     client: Client,
 }
 
-#[tower_lsp::async_trait]
+#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -1,14 +1,14 @@
 use tokio::net::{TcpListener, TcpStream};
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::*;
-use tower_lsp::{Client, LanguageServer, LspService, Server};
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::*;
+use tower_lsp_server::{Client, LanguageServer, LspService, Server};
 
 #[derive(Debug)]
 struct Backend {
     client: Client,
 }
 
-#[tower_lsp::async_trait]
+#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -1,8 +1,8 @@
 use async_tungstenite::tokio::accept_async;
 use tokio::net::TcpListener;
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types::*;
-use tower_lsp::{Client, LanguageServer, LspService, Server};
+use tower_lsp_server::jsonrpc::Result;
+use tower_lsp_server::lsp_types::*;
+use tower_lsp_server::{Client, LanguageServer, LspService, Server};
 use tracing::info;
 use ws_stream_tungstenite::*;
 
@@ -11,7 +11,7 @@ struct Backend {
     client: Client,
 }
 
-#[tower_lsp::async_trait]
+#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,16 +5,16 @@
 //! # Example
 //!
 //! ```rust
-//! use tower_lsp::jsonrpc::Result;
-//! use tower_lsp::lsp_types::*;
-//! use tower_lsp::{Client, LanguageServer, LspService, Server};
+//! use tower_lsp_server::jsonrpc::Result;
+//! use tower_lsp_server::lsp_types::*;
+//! use tower_lsp_server::{Client, LanguageServer, LspService, Server};
 //!
 //! #[derive(Debug)]
 //! struct Backend {
 //!     client: Client,
 //! }
 //!
-//! #[tower_lsp::async_trait]
+//! #[tower_lsp_server::async_trait]
 //! impl LanguageServer for Backend {
 //!     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
 //!         Ok(InitializeResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ use lsp_types::request::{
     GotoImplementationResponse, GotoTypeDefinitionParams, GotoTypeDefinitionResponse,
 };
 use lsp_types::*;
-use tower_lsp_macros::rpc;
+use tower_lsp_server_macros::rpc;
 use tracing::{error, warn};
 
 use self::jsonrpc::{Error, Result};
@@ -1371,7 +1371,7 @@ pub trait LanguageServer: Send + Sync + 'static {
         Err(Error::method_not_found())
     }
 
-    // TODO: Add `work_done_progress_cancel()` here (since 3.15.0) when supported by `tower-lsp`.
+    // TODO: Add `work_done_progress_cancel()` here (since 3.15.0) when supported by `tower-lsp-server`
     // https://github.com/ebkalderon/tower-lsp/issues/176
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -169,14 +169,14 @@ impl<S: LanguageServer> LspServiceBuilder<S> {
     ///
     /// ```rust
     /// use serde_json::{json, Value};
-    /// use tower_lsp::jsonrpc::Result;
-    /// use tower_lsp::lsp_types::*;
-    /// use tower_lsp::{LanguageServer, LspService};
+    /// use tower_lsp_server::jsonrpc::Result;
+    /// use tower_lsp_server::lsp_types::*;
+    /// use tower_lsp_server::{LanguageServer, LspService};
     ///
     /// struct Mock;
     ///
     /// // Implementation of `LanguageServer` omitted...
-    /// # #[tower_lsp::async_trait]
+    /// # #[tower_lsp_server::async_trait]
     /// # impl LanguageServer for Mock {
     /// #     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
     /// #         Ok(InitializeResult::default())

--- a/src/service/client.rs
+++ b/src/service/client.rs
@@ -466,7 +466,7 @@ impl Client {
     /// # Examples
     ///
     /// ```no_run
-    /// # use tower_lsp::{lsp_types::*, Client};
+    /// # use tower_lsp_server::{lsp_types::*, Client};
     /// #
     /// # struct Mock {
     /// #     client: Client,

--- a/tower-lsp-server-macros/Cargo.toml
+++ b/tower-lsp-server-macros/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "tower-lsp-macros"
+name = "tower-lsp-server-macros"
 version = "0.9.0"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
-description = "Internal procedural macros for tower-lsp"
+description = "Internal procedural macros for tower-lsp-server"
 edition = "2021"
 rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"
-homepage = "https://github.com/ebkalderon/tower-lsp"
-repository = "https://github.com/ebkalderon/tower-lsp"
+homepage = "https://github.com/tower-lsp-community/tower-lsp-server"
+repository = "https://github.com/tower-lsp-community/tower-lsp-server"
 
 [lib]
 proc-macro = true

--- a/tower-lsp-server-macros/src/lib.rs
+++ b/tower-lsp-server-macros/src/lib.rs
@@ -1,4 +1,4 @@
-//! Internal procedural macros for [`tower-lsp`](https://docs.rs/tower-lsp).
+//! Internal procedural macros for [`tower-lsp-server`](https://docs.rs/tower-lsp-server).
 //!
 //! This crate should not be used directly.
 

--- a/tower-lsp-server-macros/src/lib.rs
+++ b/tower-lsp-server-macros/src/lib.rs
@@ -10,7 +10,7 @@ use syn::{parse_macro_input, FnArg, ItemTrait, LitStr, ReturnType, TraitItem};
 
 /// Macro for generating LSP server implementation from [`lsp-types`](https://docs.rs/lsp-types).
 ///
-/// This procedural macro annotates the `tower_lsp::LanguageServer` trait and generates a
+/// This procedural macro annotates the `tower_lsp_server::LanguageServer` trait and generates a
 /// corresponding `register_lsp_methods()` function which registers all the methods on that trait
 /// as RPC handlers.
 #[proc_macro_attribute]


### PR DESCRIPTION
Changes project name to `tower-lsp-server` to distinguish from Eyal's repository.

The org name also has changed to `tower-lsp-community`.

Closes #3

I searched the entire repository for `tower-lsp` occurrences. I only kept references to issues of the original repository.