### PR TITLE
fix: Unconditionally close transport on exit notification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tracing = "0.1"
 [dev-dependencies]
 async-tungstenite = { version = "0.28", features = ["tokio-runtime"] }
 tokio-util = { version = "0.7", features = ["compat"] }
-tokio = { version = "1", features = ["io-util", "io-std", "macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["io-util", "io-std", "macros", "rt-multi-thread", "time"] }
 tracing-subscriber = "0.3"
 ws_stream_tungstenite = { version = "0.14", features = ["tokio_io"] }
 


### PR DESCRIPTION
Closes #12

The rationale for this change is similar to #14, but uses the request's method to determine whether to break out of the transport loop.

Based on my observations using tower-lsp in the past, some clients (e.g. Helix) may keep stdin alive even after sending the `exit` notification, thereby causing the read loop to indefinitely hang until manually killed. By checking if the request's method is in fact the exit notification, the transport loop can be closed early while not requiring a cancel token and thus changing the public API.