### PR TITLE
Add Veryl to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You can use enable proposed features in the [LSP Specification version 3.18](htt
 - [Polarity](https://github.com/polarity-lang/polarity/): both for their language server and their [interactive web demo](https://polarity-lang.github.io).
 - [Deno](https://github.com/denoland/deno/tree/main/cli/lsp) (still uses the original project)
 - [Turborepo](https://github.com/vercel/turborepo/tree/main/crates/turborepo-lsp) (still uses the original project)
+- [Veryl](https://github.com/veryl-lang/veryl)
 
 # Ecosystem
 


### PR DESCRIPTION
I used tower-lsp for LSP implementation of Veryl, and will migrate to tower-lsp-server: https://github.com/veryl-lang/veryl/pull/1510 .