### PR TITLE
add django-language-server to project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ You can use enable proposed features in the [LSP Specification version 3.18](htt
 - [Deno](https://github.com/denoland/deno/tree/main/cli/lsp) (still uses the original project)
 - [Turborepo](https://github.com/vercel/turborepo/tree/main/crates/turborepo-lsp) (still uses the original project)
 - [Veryl](https://github.com/veryl-lang/veryl)
+- [django-language-server](https://github.com/joshuadavidthomas/django-language-server)
 
 # Ecosystem
 


### PR DESCRIPTION
👋 Hiya all! Super happy the community picked this up, as I started a project last fall to build an LSP for Django projects in Rust based on tower-lsp. Once I get more of my Rust legs underneath me, I'd love to start to contribute where I can.

I'm not sure of what the criteria for adding a project to this list, or whether it's even been decided, but I figured I would at least open the PR to see. It's super early in the project and there's not a *ton* of functionality to the server yet. As well, this is a personal project at the moment, though I'm hoping I can attract more contributors as it becomes more full-featured (though that may be a *bit* of a lift for Django devs 😅).

Anyway, feel free to close this if it doesn't meet the bar for being included. Thanks again!

Swapped over in this PR -> https://github.com/joshuadavidthomas/django-language-server/pull/100