### PR TITLE
chore: use forked version of `lsp-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,12 +85,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -103,6 +97,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32"
 
 [[package]]
 name = "bytes"
@@ -173,11 +173,12 @@ dependencies = [
 
 [[package]]
 name = "fluent-uri"
-version = "0.1.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
 dependencies = [
- "bitflags 1.3.2",
+ "borrow-or-share",
+ "ref-cast",
 ]
 
 [[package]]
@@ -351,10 +352,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "lsp-types"
 version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+source = "git+https://github.com/tower-lsp-community/lsp-types?rev=7332122ee5572c3f2c247b37cd1af77289b2e1c8#7332122ee5572c3f2c247b37cd1af77289b2e1c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "fluent-uri",
  "serde",
  "serde_json",
@@ -511,7 +511,27 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -995,7 +1015,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ async-tungstenite = { version = "0.29", features = ["tokio-runtime"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tokio = { version = "1", features = ["io-util", "io-std", "macros", "rt-multi-thread", "time"] }
 tracing-subscriber = "0.3"
+
+[patch.crates-io]
+# this patch has the fix for `WorkspaceClientCapabilities`, see tower-lsp-community/tower-lsp-server#50
+lsp-types = { git = "https://github.com/tower-lsp-community/lsp-types", rev = "7332122ee5572c3f2c247b37cd1af77289b2e1c8" }

--- a/src/uri_ext.rs
+++ b/src/uri_ext.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 #[cfg(not(windows))]
 pub use std::fs::canonicalize as strict_canonicalize;
 
-/// On Windows, rewrites the wide path prefix `\\?\C:` to `C:`  
+/// On Windows, rewrites the wide path prefix `\\?\C:` to `C:`
 /// Source: https://stackoverflow.com/a/70970317
 #[inline]
 #[cfg(windows)]
@@ -70,14 +70,14 @@ impl sealed::Sealed for lsp_types::Uri {}
 
 impl UriExt for lsp_types::Uri {
     fn to_file_path(&self) -> Option<Cow<Path>> {
-        let path = match self.path().as_estr().decode().into_string_lossy() {
+        let path = match self.path().decode().into_string_lossy() {
             Cow::Borrowed(ref_) => Cow::Borrowed(Path::new(ref_)),
             Cow::Owned(owned) => Cow::Owned(PathBuf::from(owned)),
         };
 
         if cfg!(windows) {
             let authority = self.authority().expect("url has no authority component");
-            let host = authority.host().as_str();
+            let host = authority.host();
             if host.is_empty() {
                 // very high chance this is a `file:///` uri
                 // in which case the path will include a leading slash we need to remove


### PR DESCRIPTION
```
 error[E0599]: no method named `as_estr` found for reference `&fluent_uri::encoding::EStr<fluent_uri::encoding::encoder::Path>` in the current scope
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-lsp-server-0.21.1/src/uri_ext.rs:73:38
   |
73 |         let path = match self.path().as_estr().decode().into_string_lossy() {
   |                                      ^^^^^^^
   |
help: there is a method `as_str` with a similar name
   |
73 -         let path = match self.path().as_estr().decode().into_string_lossy() {
73 +         let path = match self.path().as_str().decode().into_string_lossy() {
   |

error[E0658]: use of unstable library feature `str_as_str`
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-lsp-server-0.21.1/src/uri_ext.rs:80:41
   |
80 |             let host = authority.host().as_str();
   |                                         ^^^^^^
   |
   = note: see issue #130366 <https://github.com/rust-lang/rust/issues/130366> for more information
```