### PR TITLE
fix: consistent windows driver conversion

### DIFF
--- a/src/uri_ext.rs
+++ b/src/uri_ext.rs
@@ -146,14 +146,19 @@ impl UriExt for lsp_types::Uri {
             format!(
                 "file:///{}",
                 percent_encoding::utf8_percent_encode(
-                    capitalize_drive_letter(&fragment.to_string_lossy().replace('\\', "/")),
+                    &capitalize_drive_letter(&fragment.to_string_lossy().replace('\\', "/")),
                     &ASCII_SET
                 )
             )
         };
 
         #[cfg(not(windows))]
-        let raw_uri = { format!("file://{}", percent_encoding::utf8_percent_encode(&fragment.to_string_lossy(), &ASCII_SET)) };
+        let raw_uri = {
+            format!(
+                "file://{}",
+                percent_encoding::utf8_percent_encode(&fragment.to_string_lossy(), &ASCII_SET)
+            )
+        };
 
         Self::from_str(&raw_uri).ok()
     }


### PR DESCRIPTION
Some LSP server are using the file URI as a cache-key for diagnostics or `textDocument` content. 
This is fine when the Server is not creating their own URIs, but when they need to create one, the URI object can be different.

This should keep consistency, so the consumers can be sure it is always the same URI for the same file.
