### PR TITLE
chore: add Biome and Oxc to README Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ You can use enable proposed features in the [LSP Specification version 3.18](htt
 
 # Projects using `tower-lsp-server`
 
+- [Biome](https://github.com/biomejs/biome)
+- [Oxc](https://github.com/oxc-project/oxc)
 - [Harper](https://github.com/Automattic/harper)
 - [Polarity](https://github.com/polarity-lang/polarity/): both for their language server and their [interactive web demo](https://polarity-lang.github.io).
 - [Deno](https://github.com/denoland/deno/tree/main/cli/lsp) (still uses the original project)


### PR DESCRIPTION
Hi there!
Just wanted to add to README that such cool projects like [Biome](https://github.com/biomejs/biome/blob/f0e36e223bd0784a5846a29a52c5550252cb12bb/Cargo.toml#L231) and [Oxc](https://github.com/oxc-project/oxc/blob/1c21c4681440bc39b12343d8b1d9e3873bf8c17f/Cargo.toml) successfully use this crate for their LSP implementations. Hope this would help with adoption of the fork.
Thanks for maintaining it - and good luck!