### PR TITLE
fix: use `WorkspaceSymbolResponse` in `symbol()` return value

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1220,7 +1220,7 @@ rpc! {
         async fn symbol(
             &self,
             params: WorkspaceSymbolParams,
-        ) -> Result<Option<OneOf<Vec<SymbolInformation>, Vec<WorkspaceSymbol>>>> {
+        ) -> Result<Option<WorkspaceSymbolResponse>> {
             let _ = params;
             error!("got a `workspace/symbol` request, but it is not implemented");
             Err(Error::method_not_found())


### PR DESCRIPTION
This aligns the workspace symbol method to the document symbol method, and makes use of the largely unused type. It also makes things clearer for users implementing the method, in my opinion.